### PR TITLE
Encode the access token to access token the Import/Export API

### DIFF
--- a/Immocaster/Immobilienscout/Immobilienscout.php
+++ b/Immocaster/Immobilienscout/Immobilienscout.php
@@ -233,7 +233,7 @@ class Immocaster_Immobilienscout
 		$sAccessTokenSignature = '';
 		if($sSecret)
 		{
-			$sConsKey = rawurlencode($this->_sConsumerSecret).'&'.$sSecret;
+			$sConsKey = rawurlencode($this->_sConsumerSecret) . '&' . urlencode($sSecret);
 			$sSignature = urlencode(base64_encode(hash_hmac('sha1',$req->get_signature_base_string(),$sConsKey,true)));
 			$sAccessTokenSignature = ',oauth_signature_method="HMAC-SHA1",oauth_signature="'.$sSignature.'"';
 		}


### PR DESCRIPTION
I had some problems accessing the Import/Export API which retrieves all real estate objects from an given user.  The API always told me that the signature is not valid: `Invalid signature for signature method HMAC-SHA1` but on the playground everything worked fine.

I somewhere found in the OAuth documentation that the access token has to be urlencoded, after this quick change the API worked fine.
