### PR TITLE
mime_content_type()

### DIFF
--- a/Immocaster/Immobilienscout/Immobilienscout.php
+++ b/Immocaster/Immobilienscout/Immobilienscout.php
@@ -306,7 +306,7 @@ class Immocaster_Immobilienscout
 			$aFileInfo = finfo_open(FILEINFO_MIME_TYPE);
 			$aFileInfoMime = finfo_file($aFileInfo, $aArgs['file']);
 		}
-		else if($aFileInfoMime = mime_content_type($aArgs['file']))
+		else if(function_exists('mime_content_type') && $aFileInfoMime = mime_content_type($aArgs['file']))
 		{
 			$aFileInfoMime = mime_content_type($aArgs['file']);
 		}


### PR DESCRIPTION
mime_content_type() wird übersprungen, wenn sie in PHP nicht zur
Verfügung steht.