### PR TITLE
Use oAuth with getExpose()

### DIFF
--- a/Immocaster/Immobilienscout/Rest.php
+++ b/Immocaster/Immobilienscout/Rest.php
@@ -342,13 +342,25 @@ class Immocaster_Immobilienscout_Rest extends Immocaster_Immobilienscout
      * @param array $aArgs
      * @return mixed
      */
-	private function _getExpose($aArgs)
-	{
-		$aRequired = array('exposeid');
-		$req = $this->doRequest('search/v1.0/expose/'.$aArgs['exposeid'],$aArgs,$aRequired,__FUNCTION__);
-		$req->unset_parameter('exposeid');
-		return parent::getContent($req);
-	}
+    private function _getExpose($aArgs)
+    {
+        $aRequired = array('username','exposeid');
+        $oToken = null;
+        $sSecret = null;
+        if(!isset($aArgs['username']))
+        {
+            $aArgs['username'] = $this->_sDefaultUsername;
+        }
+        list($oToken, $sSecret) = $this->getApplicationTokenAndSecret($aArgs['username']);
+        if($oToken === NULL || $sSecret === NULL)
+        {
+            return IMMOCASTER_SDK_LANG_APPLICATION_NOT_CERTIFIED;
+        }
+        $req = $this->doRequest('search/v1.0/expose/'.$aArgs['exposeid'],$aArgs,$aRequired,__FUNCTION__, $oToken);
+        $req->unset_parameter('exposeid');
+        $req->unset_parameter('username');
+        return parent::getContent($req,$sSecret);
+    }
 
 	/**
      * Abfrage eines eigenen Exposes (Offer-API)

--- a/Immocaster/Immobilienscout/Rest.php
+++ b/Immocaster/Immobilienscout/Rest.php
@@ -1,5 +1,5 @@
 <?php
-session_start();
+// session_start();
 /**
  * ImmobilienScout24 PHP-SDK
  *  Nutzung der ImmobilienScout24 API per REST.

--- a/Immocaster/Oauth/OAuth.php
+++ b/Immocaster/Oauth/OAuth.php
@@ -3,8 +3,10 @@
 
 /* Generic exception class
  */
-class OAuthException extends Exception {
-  // pass
+if (!class_exists('OAuthException')) {
+    class OAuthException extends Exception {
+        // pass
+    }
 }
 
 class OAuthConsumer {


### PR DESCRIPTION
getExpose() did not work with Objects published only for "Hompage" at IS24. With oAuth getExpose can retrieve such Objects and also "IS24" published Objects. Downside is the App needs to be certified. 

I also disabled session_start(), since this results in a E_NOTICE since php 4.3 if a Session is already started. The App code should start the session, should it not?

The OAuth class just defined the OAuthException class without checking if it already exists. This resulted in a fatal error if the PHP oAth extension is installed. 